### PR TITLE
Adding the enum delivery status field to Order

### DIFF
--- a/src/main/java/seedu/cakecollate/logic/Logic.java
+++ b/src/main/java/seedu/cakecollate/logic/Logic.java
@@ -33,6 +33,9 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of orders */
     ObservableList<Order> getFilteredOrderList();
 
+    /** Updates the deliveryStatus of an order to Status.DELIVERED if the delivery date is before the current date */
+    String updateDeliveryStatus();
+
     /**
      * Returns the user prefs' cakecollate file path.
      */

--- a/src/main/java/seedu/cakecollate/logic/LogicManager.java
+++ b/src/main/java/seedu/cakecollate/logic/LogicManager.java
@@ -2,6 +2,7 @@ package seedu.cakecollate.logic;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -14,7 +15,9 @@ import seedu.cakecollate.logic.parser.CakeCollateParser;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
 import seedu.cakecollate.model.Model;
 import seedu.cakecollate.model.ReadOnlyCakeCollate;
+import seedu.cakecollate.model.order.DeliveryStatus;
 import seedu.cakecollate.model.order.Order;
+import seedu.cakecollate.model.order.Status;
 import seedu.cakecollate.storage.Storage;
 
 /**
@@ -52,6 +55,24 @@ public class LogicManager implements Logic {
         }
 
         return commandResult;
+    }
+
+    public String updateDeliveryStatus() {
+        ObservableList<Order> orderList = getFilteredOrderList();
+        String result = "delivered";
+        boolean entered = false;
+        for (int i = 0; i < orderList.size(); i++) {
+            if (orderList.get(i).getDeliveryDate().value.isBefore(LocalDate.now())
+                    && orderList.get(i).getDeliveryStatus().equals(new DeliveryStatus(Status.DELIVERED))) {
+                result += " " + String.valueOf(i + 1);
+                entered = true;
+            }
+        }
+        if (entered) {
+            return result;
+        } else {
+            return "";
+        }
     }
 
     @Override

--- a/src/main/java/seedu/cakecollate/logic/LogicManager.java
+++ b/src/main/java/seedu/cakecollate/logic/LogicManager.java
@@ -57,6 +57,10 @@ public class LogicManager implements Logic {
         return commandResult;
     }
 
+    /**
+     * Updates the deliveryStatus to delivered if the delivery date is before the current date.
+     * @return A parsable string to update the deliveryStatus if necessary, and an empty string otherwise.
+     */
     public String updateDeliveryStatus() {
         ObservableList<Order> orderList = getFilteredOrderList();
         String result = "delivered";

--- a/src/main/java/seedu/cakecollate/logic/commands/DeliveryStatusCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/DeliveryStatusCommand.java
@@ -1,0 +1,79 @@
+package seedu.cakecollate.logic.commands;
+
+import seedu.cakecollate.commons.core.Messages;
+import seedu.cakecollate.commons.core.index.Index;
+import seedu.cakecollate.commons.core.index.IndexList;
+import seedu.cakecollate.logic.commands.exceptions.CommandException;
+import seedu.cakecollate.model.Model;
+import seedu.cakecollate.model.order.DeliveryStatus;
+import seedu.cakecollate.model.order.Order;
+import seedu.cakecollate.model.order.Status;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.cakecollate.logic.parser.CliSyntax.*;
+import static seedu.cakecollate.model.Model.PREDICATE_SHOW_ALL_ORDERS;
+
+public class DeliveryStatusCommand extends Command {
+
+    public static final String DELIVERED_COMMAND_WORD = "delivered";
+
+    public static final String CANCELLED_COMMAND_WORD = "cancelled";
+
+    public static final String MESSAGE_USAGE = ": Updates the details of the deliveryStatus of the order identified "
+            + "by the index number used in the displayed order list. "
+            + "Existing deliveryStatus will be overwritten by the input values.\n"
+            + "Parameters: INDEXES (must be positive integers) \n"
+            + "Example: "  + " 1 2 3";
+
+    public static final String MESSAGE_DELIVERYSTATUS_ORDER_SUCCESS = "Updated order status for: %1$s";
+
+    private final IndexList targetIndexList;
+
+    private final DeliveryStatus status;
+
+    public DeliveryStatusCommand(IndexList targetIndexList, DeliveryStatus status) {
+        this.targetIndexList = targetIndexList;
+        this.status = status;
+    }
+
+    public static String getResultString(List<Order> ordersToUpdate) {
+        String convertedToString = "";
+        for (Order order : ordersToUpdate) {
+            convertedToString = convertedToString + String.format("\n%1$s", order);
+        }
+        return String.format(MESSAGE_DELIVERYSTATUS_ORDER_SUCCESS, convertedToString);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Order> lastShownList = model.getFilteredOrderList();
+        List<Order> updatedOrders = new ArrayList<>();
+        for (Index targetIndex:this.targetIndexList.getIndexList()) {
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+            }
+            Order orderToUpdate = lastShownList.get(targetIndex.getZeroBased());
+            Order editedOrder = updateOrder(orderToUpdate, status);
+            model.setOrder(orderToUpdate, editedOrder);
+            model.updateFilteredOrderList(PREDICATE_SHOW_ALL_ORDERS);
+            updatedOrders.add(orderToUpdate);
+        }
+        return new CommandResult(getResultString(updatedOrders));
+    }
+
+    private static Order updateOrder(Order order, DeliveryStatus status) {
+        return new Order(order.getName(), order.getPhone(), order.getEmail(), order.getAddress(),
+                order.getOrderDescriptions(), order.getTags(), order.getDeliveryDate(), status);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeliveryStatusCommand // instanceof handles nulls
+                && targetIndexList.equals(((DeliveryStatusCommand) other).targetIndexList)); // state check
+    }
+}

--- a/src/main/java/seedu/cakecollate/logic/commands/DeliveryStatusCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/DeliveryStatusCommand.java
@@ -22,13 +22,21 @@ public class DeliveryStatusCommand extends Command {
 
     public static final String CANCELLED_COMMAND_WORD = "cancelled";
 
-    public static final String MESSAGE_USAGE = ": Updates the details of the deliveryStatus of the order identified "
-            + "by the index number used in the displayed order list. "
-            + "Existing deliveryStatus will be overwritten by the input values.\n"
-            + "Parameters: INDEXES (must be positive integers) \n"
-            + "Example: "  + " 1 2 3";
+    public static final String DELIVERED_MESSAGE_USAGE = DELIVERED_COMMAND_WORD
+            + ": Updates the deliveryStatus of the order identified by the index number "
+            + "used in the displayed order list to DELIVERED.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + DELIVERED_COMMAND_WORD + " 1 2 3";
 
-    public static final String MESSAGE_DELIVERYSTATUS_ORDER_SUCCESS = "Updated order status for: %1$s";
+    public static final String CANCELLED_MESSAGE_USAGE = CANCELLED_COMMAND_WORD
+            + ": Updates the deliveryStatus of the order identified by the index number "
+            + "used in the displayed order list to CANCELLED.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + CANCELLED_COMMAND_WORD + " 1 2 3";
+
+    public static final String MESSAGE_USAGE = DELIVERED_MESSAGE_USAGE + CANCELLED_MESSAGE_USAGE;
+
+    public static final String MESSAGE_DELIVERY_STATUS_ORDER_SUCCESS = "Updated order status for: %1$s";
 
     private final IndexList targetIndexList;
 
@@ -44,7 +52,7 @@ public class DeliveryStatusCommand extends Command {
         for (Order order : ordersToUpdate) {
             convertedToString = convertedToString + String.format("\n%1$s", order);
         }
-        return String.format(MESSAGE_DELIVERYSTATUS_ORDER_SUCCESS, convertedToString);
+        return String.format(MESSAGE_DELIVERY_STATUS_ORDER_SUCCESS, convertedToString);
     }
 
     @Override

--- a/src/main/java/seedu/cakecollate/logic/commands/DeliveryStatusCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/DeliveryStatusCommand.java
@@ -86,6 +86,7 @@ public class DeliveryStatusCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DeliveryStatusCommand // instanceof handles nulls
-                && targetIndexList.equals(((DeliveryStatusCommand) other).targetIndexList)); // state check
+                && targetIndexList.equals(((DeliveryStatusCommand) other).targetIndexList)
+                && status.equals(((DeliveryStatusCommand) other).status)); // state check
     }
 }

--- a/src/main/java/seedu/cakecollate/logic/commands/DeliveryStatusCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/DeliveryStatusCommand.java
@@ -18,23 +18,23 @@ import static seedu.cakecollate.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 
 public class DeliveryStatusCommand extends Command {
 
+    public static final String UNDELIVERED_COMMAND_WORD = "undelivered";
+
     public static final String DELIVERED_COMMAND_WORD = "delivered";
 
     public static final String CANCELLED_COMMAND_WORD = "cancelled";
 
-    public static final String DELIVERED_MESSAGE_USAGE = DELIVERED_COMMAND_WORD
-            + ": Updates the deliveryStatus of the order identified by the index number "
-            + "used in the displayed order list to DELIVERED.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + DELIVERED_COMMAND_WORD + " 1 2 3";
+    public static String messageUsage(String commandWord) {
+        return commandWord
+                + ": Updates the deliveryStatus of the order identified by the index number "
+                + "used in the displayed order list to " + commandWord + ".\n"
+                + "Parameters: INDEX (must be a positive integer)\n"
+                + "Example: " + commandWord + " 1 2 3";
+    }
 
-    public static final String CANCELLED_MESSAGE_USAGE = CANCELLED_COMMAND_WORD
-            + ": Updates the deliveryStatus of the order identified by the index number "
-            + "used in the displayed order list to CANCELLED.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + CANCELLED_COMMAND_WORD + " 1 2 3";
-
-    public static final String MESSAGE_USAGE = DELIVERED_MESSAGE_USAGE + CANCELLED_MESSAGE_USAGE;
+    public static String getMessageUsage(String commandWord) {
+        return messageUsage(commandWord.toLowerCase());
+    }
 
     public static final String MESSAGE_DELIVERY_STATUS_ORDER_SUCCESS = "Updated order status for: %1$s";
 

--- a/src/main/java/seedu/cakecollate/logic/commands/DeliveryStatusCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/DeliveryStatusCommand.java
@@ -1,5 +1,11 @@
 package seedu.cakecollate.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.cakecollate.model.Model.PREDICATE_SHOW_ALL_ORDERS;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import seedu.cakecollate.commons.core.Messages;
 import seedu.cakecollate.commons.core.index.Index;
 import seedu.cakecollate.commons.core.index.IndexList;
@@ -7,14 +13,6 @@ import seedu.cakecollate.logic.commands.exceptions.CommandException;
 import seedu.cakecollate.model.Model;
 import seedu.cakecollate.model.order.DeliveryStatus;
 import seedu.cakecollate.model.order.Order;
-import seedu.cakecollate.model.order.Status;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.cakecollate.logic.parser.CliSyntax.*;
-import static seedu.cakecollate.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 
 public class DeliveryStatusCommand extends Command {
 
@@ -24,6 +22,23 @@ public class DeliveryStatusCommand extends Command {
 
     public static final String CANCELLED_COMMAND_WORD = "cancelled";
 
+    public static final String MESSAGE_DELIVERY_STATUS_ORDER_SUCCESS = "Updated order status for: %1$s";
+
+    private final IndexList targetIndexList;
+
+    private final DeliveryStatus status;
+
+    /**
+     * Initialises a delivery status command.
+     * @param targetIndexList IndexList of the indices that need to be updated.
+     * @param status The status the deliveryStatus has to be changed to.
+     */
+    public DeliveryStatusCommand(IndexList targetIndexList, DeliveryStatus status) {
+        this.targetIndexList = targetIndexList;
+        this.status = status;
+    }
+
+    /** Returns the description of how each of the commands in DeliveryStatusCommand works. */
     public static String messageUsage(String commandWord) {
         return commandWord
                 + ": Updates the deliveryStatus of the order identified by the index number "
@@ -34,17 +49,6 @@ public class DeliveryStatusCommand extends Command {
 
     public static String getMessageUsage(String commandWord) {
         return messageUsage(commandWord.toLowerCase());
-    }
-
-    public static final String MESSAGE_DELIVERY_STATUS_ORDER_SUCCESS = "Updated order status for: %1$s";
-
-    private final IndexList targetIndexList;
-
-    private final DeliveryStatus status;
-
-    public DeliveryStatusCommand(IndexList targetIndexList, DeliveryStatus status) {
-        this.targetIndexList = targetIndexList;
-        this.status = status;
     }
 
     public static String getResultString(List<Order> ordersToUpdate) {

--- a/src/main/java/seedu/cakecollate/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/EditCommand.java
@@ -21,13 +21,7 @@ import seedu.cakecollate.commons.core.index.Index;
 import seedu.cakecollate.commons.util.CollectionUtil;
 import seedu.cakecollate.logic.commands.exceptions.CommandException;
 import seedu.cakecollate.model.Model;
-import seedu.cakecollate.model.order.Address;
-import seedu.cakecollate.model.order.DeliveryDate;
-import seedu.cakecollate.model.order.Email;
-import seedu.cakecollate.model.order.Name;
-import seedu.cakecollate.model.order.Order;
-import seedu.cakecollate.model.order.OrderDescription;
-import seedu.cakecollate.model.order.Phone;
+import seedu.cakecollate.model.order.*;
 import seedu.cakecollate.model.tag.Tag;
 
 /**
@@ -107,9 +101,10 @@ public class EditCommand extends Command {
         Set<Tag> updatedTags = editOrderDescriptor.getTags().orElse(orderToEdit.getTags());
         DeliveryDate updatedDeliveryDate =
                 editOrderDescriptor.getDeliveryDate().orElse(orderToEdit.getDeliveryDate());
+        DeliveryStatus deliveryStatus = orderToEdit.getDeliveryStatus();
 
         return new Order(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedOrderDescriptions,
-                updatedTags, updatedDeliveryDate);
+                updatedTags, updatedDeliveryDate, deliveryStatus);
     }
 
     @Override

--- a/src/main/java/seedu/cakecollate/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/EditCommand.java
@@ -21,7 +21,14 @@ import seedu.cakecollate.commons.core.index.Index;
 import seedu.cakecollate.commons.util.CollectionUtil;
 import seedu.cakecollate.logic.commands.exceptions.CommandException;
 import seedu.cakecollate.model.Model;
-import seedu.cakecollate.model.order.*;
+import seedu.cakecollate.model.order.Address;
+import seedu.cakecollate.model.order.DeliveryDate;
+import seedu.cakecollate.model.order.DeliveryStatus;
+import seedu.cakecollate.model.order.Email;
+import seedu.cakecollate.model.order.Name;
+import seedu.cakecollate.model.order.Order;
+import seedu.cakecollate.model.order.OrderDescription;
+import seedu.cakecollate.model.order.Phone;
 import seedu.cakecollate.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/cakecollate/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/HelpCommand.java
@@ -25,7 +25,8 @@ public class HelpCommand extends Command {
     public static void addAllCommands() {
         listOfCommands.addAll(HelpCommand.MESSAGE_USAGE, AddCommand.MESSAGE_USAGE, ListCommand.MESSAGE_USAGE,
                 EditCommand.MESSAGE_USAGE, FindCommand.MESSAGE_USAGE, DeleteCommand.MESSAGE_USAGE,
-                ClearCommand.MESSAGE_USAGE, ExitCommand.MESSAGE_USAGE, RemindCommand.MESSAGE_USAGE);
+                ClearCommand.MESSAGE_USAGE, ExitCommand.MESSAGE_USAGE, RemindCommand.MESSAGE_USAGE,
+                DeliveryStatusCommand.DELIVERED_MESSAGE_USAGE, DeliveryStatusCommand.CANCELLED_MESSAGE_USAGE);
     }
 
     public static ObservableList<String> getListOfCommands() {

--- a/src/main/java/seedu/cakecollate/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/HelpCommand.java
@@ -3,6 +3,7 @@ package seedu.cakecollate.logic.commands;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.cakecollate.model.Model;
+import seedu.cakecollate.model.order.DeliveryStatus;
 
 /**
  * Format full help instructions for every command for display.
@@ -26,7 +27,9 @@ public class HelpCommand extends Command {
         listOfCommands.addAll(HelpCommand.MESSAGE_USAGE, AddCommand.MESSAGE_USAGE, ListCommand.MESSAGE_USAGE,
                 EditCommand.MESSAGE_USAGE, FindCommand.MESSAGE_USAGE, DeleteCommand.MESSAGE_USAGE,
                 ClearCommand.MESSAGE_USAGE, ExitCommand.MESSAGE_USAGE, RemindCommand.MESSAGE_USAGE,
-                DeliveryStatusCommand.DELIVERED_MESSAGE_USAGE, DeliveryStatusCommand.CANCELLED_MESSAGE_USAGE);
+                DeliveryStatusCommand.getMessageUsage(DeliveryStatusCommand.UNDELIVERED_COMMAND_WORD),
+                DeliveryStatusCommand.getMessageUsage(DeliveryStatusCommand.DELIVERED_COMMAND_WORD),
+                DeliveryStatusCommand.getMessageUsage(DeliveryStatusCommand.CANCELLED_COMMAND_WORD));
     }
 
     public static ObservableList<String> getListOfCommands() {

--- a/src/main/java/seedu/cakecollate/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/HelpCommand.java
@@ -3,7 +3,6 @@ package seedu.cakecollate.logic.commands;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.cakecollate.model.Model;
-import seedu.cakecollate.model.order.DeliveryStatus;
 
 /**
  * Format full help instructions for every command for display.

--- a/src/main/java/seedu/cakecollate/logic/parser/CakeCollateParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/CakeCollateParser.java
@@ -65,11 +65,11 @@ public class CakeCollateParser {
         case RemindCommand.COMMAND_WORD:
             return new RemindCommandParser().parse(arguments);
 
-            case DeliveryStatusCommand.DELIVERED_COMMAND_WORD:
-                return new DeliveryStatusCommandParser(new DeliveryStatus(Status.DELIVERED)).parse(arguments);
+        case DeliveryStatusCommand.DELIVERED_COMMAND_WORD:
+            return new DeliveryStatusCommandParser(new DeliveryStatus(Status.DELIVERED)).parse(arguments);
 
-            case DeliveryStatusCommand.CANCELLED_COMMAND_WORD:
-                return new DeliveryStatusCommandParser(new DeliveryStatus(Status.CANCELLED)).parse(arguments);
+        case DeliveryStatusCommand.CANCELLED_COMMAND_WORD:
+            return new DeliveryStatusCommandParser(new DeliveryStatus(Status.CANCELLED)).parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/cakecollate/logic/parser/CakeCollateParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/CakeCollateParser.java
@@ -6,17 +6,10 @@ import static seedu.cakecollate.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.cakecollate.logic.commands.AddCommand;
-import seedu.cakecollate.logic.commands.ClearCommand;
-import seedu.cakecollate.logic.commands.Command;
-import seedu.cakecollate.logic.commands.DeleteCommand;
-import seedu.cakecollate.logic.commands.EditCommand;
-import seedu.cakecollate.logic.commands.ExitCommand;
-import seedu.cakecollate.logic.commands.FindCommand;
-import seedu.cakecollate.logic.commands.HelpCommand;
-import seedu.cakecollate.logic.commands.ListCommand;
-import seedu.cakecollate.logic.commands.RemindCommand;
+import seedu.cakecollate.logic.commands.*;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
+import seedu.cakecollate.model.order.DeliveryStatus;
+import seedu.cakecollate.model.order.Status;
 
 /**
  * Parses user input.
@@ -71,6 +64,12 @@ public class CakeCollateParser {
 
         case RemindCommand.COMMAND_WORD:
             return new RemindCommandParser().parse(arguments);
+
+            case DeliveryStatusCommand.DELIVERED_COMMAND_WORD:
+                return new DeliveryStatusCommandParser(new DeliveryStatus(Status.DELIVERED)).parse(arguments);
+
+            case DeliveryStatusCommand.CANCELLED_COMMAND_WORD:
+                return new DeliveryStatusCommandParser(new DeliveryStatus(Status.CANCELLED)).parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/cakecollate/logic/parser/CakeCollateParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/CakeCollateParser.java
@@ -65,6 +65,9 @@ public class CakeCollateParser {
         case RemindCommand.COMMAND_WORD:
             return new RemindCommandParser().parse(arguments);
 
+        case DeliveryStatusCommand.UNDELIVERED_COMMAND_WORD:
+            return new DeliveryStatusCommandParser(new DeliveryStatus(Status.UNDELIVERED)).parse(arguments);
+
         case DeliveryStatusCommand.DELIVERED_COMMAND_WORD:
             return new DeliveryStatusCommandParser(new DeliveryStatus(Status.DELIVERED)).parse(arguments);
 

--- a/src/main/java/seedu/cakecollate/logic/parser/CakeCollateParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/CakeCollateParser.java
@@ -6,7 +6,17 @@ import static seedu.cakecollate.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.cakecollate.logic.commands.*;
+import seedu.cakecollate.logic.commands.AddCommand;
+import seedu.cakecollate.logic.commands.ClearCommand;
+import seedu.cakecollate.logic.commands.Command;
+import seedu.cakecollate.logic.commands.DeleteCommand;
+import seedu.cakecollate.logic.commands.DeliveryStatusCommand;
+import seedu.cakecollate.logic.commands.EditCommand;
+import seedu.cakecollate.logic.commands.ExitCommand;
+import seedu.cakecollate.logic.commands.FindCommand;
+import seedu.cakecollate.logic.commands.HelpCommand;
+import seedu.cakecollate.logic.commands.ListCommand;
+import seedu.cakecollate.logic.commands.RemindCommand;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
 import seedu.cakecollate.model.order.DeliveryStatus;
 import seedu.cakecollate.model.order.Status;

--- a/src/main/java/seedu/cakecollate/logic/parser/DeliveryStatusCommandParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/DeliveryStatusCommandParser.java
@@ -1,14 +1,11 @@
 package seedu.cakecollate.logic.parser;
 
+import static seedu.cakecollate.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.cakecollate.commons.core.index.IndexList;
-import seedu.cakecollate.logic.commands.DeleteCommand;
 import seedu.cakecollate.logic.commands.DeliveryStatusCommand;
-import seedu.cakecollate.logic.commands.exceptions.CommandException;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
 import seedu.cakecollate.model.order.DeliveryStatus;
-import seedu.cakecollate.model.order.Status;
-
-import static seedu.cakecollate.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 public class DeliveryStatusCommandParser implements Parser<DeliveryStatusCommand> {
 
@@ -28,8 +25,8 @@ public class DeliveryStatusCommandParser implements Parser<DeliveryStatusCommand
             IndexList indexList = ParserUtil.parseIndexList(args);
             return new DeliveryStatusCommand(indexList, status);
         } catch (ParseException exception) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeliveryStatusCommand.getMessageUsage(status.toString())), exception);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    DeliveryStatusCommand.getMessageUsage(status.toString())), exception);
         }
     }
 }

--- a/src/main/java/seedu/cakecollate/logic/parser/DeliveryStatusCommandParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/DeliveryStatusCommandParser.java
@@ -1,0 +1,34 @@
+package seedu.cakecollate.logic.parser;
+
+import seedu.cakecollate.commons.core.index.IndexList;
+import seedu.cakecollate.logic.commands.DeleteCommand;
+import seedu.cakecollate.logic.commands.DeliveryStatusCommand;
+import seedu.cakecollate.logic.parser.exceptions.ParseException;
+import seedu.cakecollate.model.order.DeliveryStatus;
+import seedu.cakecollate.model.order.Status;
+
+import static seedu.cakecollate.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+public class DeliveryStatusCommandParser implements Parser<DeliveryStatusCommand> {
+
+    public final DeliveryStatus status;
+
+    DeliveryStatusCommandParser(DeliveryStatus status) {
+        this.status = status;
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeliveryStatusCommand
+     * and returns a DeliveryStatusCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeliveryStatusCommand parse(String args) throws ParseException {
+        try {
+            IndexList indexList = ParserUtil.parseIndexList(args);
+            return new DeliveryStatusCommand(indexList, status);
+        } catch (ParseException exception) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeliveryStatusCommand.MESSAGE_USAGE), exception);
+        }
+    }
+}

--- a/src/main/java/seedu/cakecollate/logic/parser/DeliveryStatusCommandParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/DeliveryStatusCommandParser.java
@@ -3,6 +3,7 @@ package seedu.cakecollate.logic.parser;
 import seedu.cakecollate.commons.core.index.IndexList;
 import seedu.cakecollate.logic.commands.DeleteCommand;
 import seedu.cakecollate.logic.commands.DeliveryStatusCommand;
+import seedu.cakecollate.logic.commands.exceptions.CommandException;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
 import seedu.cakecollate.model.order.DeliveryStatus;
 import seedu.cakecollate.model.order.Status;
@@ -28,7 +29,7 @@ public class DeliveryStatusCommandParser implements Parser<DeliveryStatusCommand
             return new DeliveryStatusCommand(indexList, status);
         } catch (ParseException exception) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeliveryStatusCommand.MESSAGE_USAGE), exception);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeliveryStatusCommand.getMessageUsage(status.toString())), exception);
         }
     }
 }

--- a/src/main/java/seedu/cakecollate/model/ModelManager.java
+++ b/src/main/java/seedu/cakecollate/model/ModelManager.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.cakecollate.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
-import java.time.LocalDate;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -12,9 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.cakecollate.commons.core.GuiSettings;
 import seedu.cakecollate.commons.core.LogsCenter;
-import seedu.cakecollate.logic.parser.DeliveryStatusCommandParser;
 import seedu.cakecollate.model.order.Order;
-import seedu.cakecollate.model.order.Status;
 
 /**
  * Represents the in-memory model of the cakecollate data.

--- a/src/main/java/seedu/cakecollate/model/ModelManager.java
+++ b/src/main/java/seedu/cakecollate/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.cakecollate.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -11,7 +12,9 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.cakecollate.commons.core.GuiSettings;
 import seedu.cakecollate.commons.core.LogsCenter;
+import seedu.cakecollate.logic.parser.DeliveryStatusCommandParser;
 import seedu.cakecollate.model.order.Order;
+import seedu.cakecollate.model.order.Status;
 
 /**
  * Represents the in-memory model of the cakecollate data.

--- a/src/main/java/seedu/cakecollate/model/order/DeliveryStatus.java
+++ b/src/main/java/seedu/cakecollate/model/order/DeliveryStatus.java
@@ -11,7 +11,7 @@ public class DeliveryStatus {
 
     public Status deliveryStatus;
 
-    DeliveryStatus() {
+    public DeliveryStatus() {
         this.deliveryStatus = Status.UNDELIVERED;
     }
 

--- a/src/main/java/seedu/cakecollate/model/order/DeliveryStatus.java
+++ b/src/main/java/seedu/cakecollate/model/order/DeliveryStatus.java
@@ -15,6 +15,10 @@ public class DeliveryStatus {
         this.deliveryStatus = Status.UNDELIVERED;
     }
 
+    public DeliveryStatus(Status status) {
+        this.deliveryStatus = status;
+    }
+
     public Status getDeliveryStatus() {
         return deliveryStatus;
     }

--- a/src/main/java/seedu/cakecollate/model/order/DeliveryStatus.java
+++ b/src/main/java/seedu/cakecollate/model/order/DeliveryStatus.java
@@ -1,0 +1,42 @@
+package seedu.cakecollate.model.order;
+
+import java.util.Arrays;
+
+public class DeliveryStatus {
+    public static final String MESSAGE_CONSTRAINTS = "The delivery status should be a valid enum value.";
+
+    public static final String[] stringRepresentation = Arrays.stream(Status.values())
+            .map(Enum::name)
+            .toArray(String[]::new);
+
+    public Status deliveryStatus;
+
+    DeliveryStatus() {
+        this.deliveryStatus = Status.UNDELIVERED;
+    }
+
+    public Status getDeliveryStatus() {
+        return deliveryStatus;
+    }
+
+    public void setDeliveryStatus(Status status) {
+        deliveryStatus = status;
+    }
+
+    @Override
+    public String toString() {
+        return stringRepresentation[deliveryStatus.ordinal()];
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof DeliveryStatus
+                && deliveryStatus.equals(((DeliveryStatus) other).deliveryStatus));
+    }
+
+    @Override
+    public int hashCode() {
+        return deliveryStatus.hashCode();
+    }
+}

--- a/src/main/java/seedu/cakecollate/model/order/DeliveryStatus.java
+++ b/src/main/java/seedu/cakecollate/model/order/DeliveryStatus.java
@@ -5,11 +5,11 @@ import java.util.Arrays;
 public class DeliveryStatus {
     public static final String MESSAGE_CONSTRAINTS = "The delivery status should be a valid enum value.";
 
-    public static final String[] stringRepresentation = Arrays.stream(Status.values())
+    public static final String[] STRING_REPRESENTATION = Arrays.stream(Status.values())
             .map(Enum::name)
             .toArray(String[]::new);
 
-    public Status deliveryStatus;
+    private Status deliveryStatus;
 
     public DeliveryStatus() {
         this.deliveryStatus = Status.UNDELIVERED;
@@ -29,7 +29,7 @@ public class DeliveryStatus {
 
     @Override
     public String toString() {
-        return stringRepresentation[deliveryStatus.ordinal()];
+        return STRING_REPRESENTATION[deliveryStatus.ordinal()];
     }
 
     @Override

--- a/src/main/java/seedu/cakecollate/model/order/Order.java
+++ b/src/main/java/seedu/cakecollate/model/order/Order.java
@@ -44,6 +44,17 @@ public class Order {
         this.deliveryStatus = new DeliveryStatus();
     }
 
+    /**
+     * Initialises an order.
+     * @param name Name of the customer.
+     * @param phone Phone number of the customer.
+     * @param email Email of the customer.
+     * @param address Address of the customer.
+     * @param orderDescriptions Order descriptions of the orders made by the customer.
+     * @param tags Tags for the order.
+     * @param deliveryDate Delivery date of the order.
+     * @param deliveryStatus Delivery status of the order.
+     */
     public Order(Name name, Phone phone, Email email, Address address, Set<OrderDescription> orderDescriptions,
                  Set<Tag> tags, DeliveryDate deliveryDate, DeliveryStatus deliveryStatus) {
         requireAllNonNull(name, phone, email, address, orderDescriptions, tags, deliveryDate);
@@ -89,12 +100,13 @@ public class Order {
         return Collections.unmodifiableSet(tags);
     }
 
-
     public DeliveryDate getDeliveryDate() {
         return deliveryDate;
     }
 
-    public DeliveryStatus getDeliveryStatus() { return deliveryStatus; }
+    public DeliveryStatus getDeliveryStatus() {
+        return deliveryStatus;
+    }
 
     /**
      * Returns true if both orders have the same name.

--- a/src/main/java/seedu/cakecollate/model/order/Order.java
+++ b/src/main/java/seedu/cakecollate/model/order/Order.java
@@ -44,6 +44,19 @@ public class Order {
         this.deliveryStatus = new DeliveryStatus();
     }
 
+    public Order(Name name, Phone phone, Email email, Address address, Set<OrderDescription> orderDescriptions,
+                 Set<Tag> tags, DeliveryDate deliveryDate, DeliveryStatus deliveryStatus) {
+        requireAllNonNull(name, phone, email, address, orderDescriptions, tags, deliveryDate);
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+        this.orderDescriptions.addAll(orderDescriptions);
+        this.tags.addAll(tags);
+        this.deliveryDate = deliveryDate;
+        this.deliveryStatus = deliveryStatus;
+    }
+
     public Name getName() {
         return name;
     }

--- a/src/main/java/seedu/cakecollate/model/order/Order.java
+++ b/src/main/java/seedu/cakecollate/model/order/Order.java
@@ -25,6 +25,7 @@ public class Order {
     private final Set<Tag> tags = new HashSet<>();
     private final Set<OrderDescription> orderDescriptions = new HashSet<>();
     private final DeliveryDate deliveryDate;
+    private final DeliveryStatus deliveryStatus;
 
     /**
      * Every field must be present and not null.
@@ -40,6 +41,7 @@ public class Order {
         this.orderDescriptions.addAll(orderDescriptions);
         this.tags.addAll(tags);
         this.deliveryDate = deliveryDate;
+        this.deliveryStatus = new DeliveryStatus();
     }
 
     public Name getName() {
@@ -79,6 +81,8 @@ public class Order {
         return deliveryDate;
     }
 
+    public DeliveryStatus getDeliveryStatus() { return deliveryStatus; }
+
     /**
      * Returns true if both orders have the same name.
      * This defines a weaker notion of equality between two orders.
@@ -113,13 +117,14 @@ public class Order {
                 && otherOrder.getAddress().equals(getAddress())
                 && otherOrder.getOrderDescriptions().equals(getOrderDescriptions())
                 && otherOrder.getTags().equals(getTags())
-                && otherOrder.getDeliveryDate().equals(getDeliveryDate());
+                && otherOrder.getDeliveryDate().equals(getDeliveryDate())
+                && otherOrder.getDeliveryStatus().equals(getDeliveryStatus());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags, deliveryDate);
+        return Objects.hash(name, phone, email, address, tags, deliveryDate, deliveryStatus);
     }
 
     @Override
@@ -147,7 +152,9 @@ public class Order {
         }
 
         builder.append("; DeliveryDate: ")
-                .append(getDeliveryDate());
+                .append(getDeliveryDate())
+                .append("; DeliveryStatus: ")
+                .append(getDeliveryStatus());
 
         return builder.toString();
     }

--- a/src/main/java/seedu/cakecollate/model/order/Status.java
+++ b/src/main/java/seedu/cakecollate/model/order/Status.java
@@ -1,0 +1,7 @@
+package seedu.cakecollate.model.order;
+
+public enum Status {
+    UNDELIVERED,
+    DELIVERED,
+    CANCELLED
+}

--- a/src/main/java/seedu/cakecollate/storage/JsonAdaptedOrder.java
+++ b/src/main/java/seedu/cakecollate/storage/JsonAdaptedOrder.java
@@ -10,13 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.cakecollate.commons.exceptions.IllegalValueException;
-import seedu.cakecollate.model.order.Address;
-import seedu.cakecollate.model.order.DeliveryDate;
-import seedu.cakecollate.model.order.Email;
-import seedu.cakecollate.model.order.Name;
-import seedu.cakecollate.model.order.Order;
-import seedu.cakecollate.model.order.OrderDescription;
-import seedu.cakecollate.model.order.Phone;
+import seedu.cakecollate.model.order.*;
 import seedu.cakecollate.model.tag.Tag;
 
 /**
@@ -33,6 +27,7 @@ class JsonAdaptedOrder {
     private final List<JsonAdaptedOrderDescription> orderDescriptions = new ArrayList<>();
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
     private final String deliveryDate;
+    private final Status deliveryStatus;
 
     /**
      * Constructs a {@code JsonAdaptedOrder} with the given order details.
@@ -42,7 +37,8 @@ class JsonAdaptedOrder {
                             @JsonProperty("email") String email, @JsonProperty("cakecollate") String address,
                             @JsonProperty("orderDescriptions") List<JsonAdaptedOrderDescription> orderDescriptions,
                             @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
-                            @JsonProperty("deliveryDate") String deliveryDate) {
+                            @JsonProperty("deliveryDate") String deliveryDate,
+                            @JsonProperty("deliveryStatus") Status status) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -54,6 +50,7 @@ class JsonAdaptedOrder {
             this.tagged.addAll(tagged);
         }
         this.deliveryDate = deliveryDate;
+        this.deliveryStatus = status;
     }
 
     /**
@@ -72,6 +69,7 @@ class JsonAdaptedOrder {
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
         deliveryDate = source.getDeliveryDate().toString();
+        deliveryStatus = source.getDeliveryStatus().getDeliveryStatus();
     }
 
     /**
@@ -139,8 +137,18 @@ class JsonAdaptedOrder {
         }
         final Set<OrderDescription> modelOrderDescriptions = new HashSet<>(orderOrderDescriptions);
 
+        final DeliveryStatus modelDeliveryStatus;
+        if (deliveryStatus == null) {
+            modelDeliveryStatus = new DeliveryStatus();
+        } else {
+            modelDeliveryStatus = new DeliveryStatus(deliveryStatus);
+        }
+
         return new Order(modelName, modelPhone, modelEmail, modelAddress, modelOrderDescriptions, modelTags,
-                modelDeliveryDate);
+                modelDeliveryDate, modelDeliveryStatus);
     }
 
 }
+
+
+

--- a/src/main/java/seedu/cakecollate/storage/JsonAdaptedOrder.java
+++ b/src/main/java/seedu/cakecollate/storage/JsonAdaptedOrder.java
@@ -10,7 +10,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.cakecollate.commons.exceptions.IllegalValueException;
-import seedu.cakecollate.model.order.*;
+import seedu.cakecollate.model.order.Address;
+import seedu.cakecollate.model.order.DeliveryDate;
+import seedu.cakecollate.model.order.DeliveryStatus;
+import seedu.cakecollate.model.order.Email;
+import seedu.cakecollate.model.order.Name;
+import seedu.cakecollate.model.order.Order;
+import seedu.cakecollate.model.order.OrderDescription;
+import seedu.cakecollate.model.order.Phone;
+import seedu.cakecollate.model.order.Status;
 import seedu.cakecollate.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/cakecollate/ui/MainWindow.java
+++ b/src/main/java/seedu/cakecollate/ui/MainWindow.java
@@ -114,7 +114,7 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Fills up all the placeholders of this window.
      */
-    void fillInnerParts() throws ParseException, CommandException {
+    void fillInnerParts() {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
@@ -123,7 +123,9 @@ public class MainWindow extends UiPart<Stage> {
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
+    }
 
+    void updateDeliveryStatuses() throws ParseException, CommandException {
         String deliveryStatus = logic.updateDeliveryStatus();
         if (!deliveryStatus.isEmpty()) {
             executeCommand(logic.updateDeliveryStatus());

--- a/src/main/java/seedu/cakecollate/ui/MainWindow.java
+++ b/src/main/java/seedu/cakecollate/ui/MainWindow.java
@@ -216,6 +216,10 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
+            if (inHelp && !commandResult.isShowHelp()) {
+                resetMainWindow();
+            }
+
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("Invalid command: " + commandText);

--- a/src/main/java/seedu/cakecollate/ui/MainWindow.java
+++ b/src/main/java/seedu/cakecollate/ui/MainWindow.java
@@ -58,7 +58,7 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
      */
-    public MainWindow(Stage primaryStage, Logic logic) {
+    public MainWindow(Stage primaryStage, Logic logic) throws CommandException, ParseException {
         super(FXML, primaryStage);
 
         // Set dependencies
@@ -114,7 +114,7 @@ public class MainWindow extends UiPart<Stage> {
     /**
      * Fills up all the placeholders of this window.
      */
-    void fillInnerParts() {
+    void fillInnerParts() throws ParseException, CommandException {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
@@ -123,6 +123,11 @@ public class MainWindow extends UiPart<Stage> {
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
+
+        String deliveryStatus = logic.updateDeliveryStatus();
+        if (!deliveryStatus.isEmpty()) {
+            executeCommand(logic.updateDeliveryStatus());
+        }
     }
 
     void fillOrderListPanel() {

--- a/src/main/java/seedu/cakecollate/ui/OrderCard.java
+++ b/src/main/java/seedu/cakecollate/ui/OrderCard.java
@@ -8,6 +8,7 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.cakecollate.model.order.Order;
+import seedu.cakecollate.model.order.Status;
 
 /**
  * An UI component that displays information of a {@code Order}.
@@ -43,6 +44,8 @@ public class OrderCard extends UiPart<Region> {
     @FXML
     private Label deliveryDate;
     @FXML
+    private Label deliveryStatus;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -63,6 +66,12 @@ public class OrderCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         deliveryDate.setText(order.getDeliveryDate().toString());
+        deliveryStatus.setText(order.getDeliveryStatus().toString());
+        setDeliveryStatusStyle();
+    }
+
+    public void setDeliveryStatusStyle() {
+        deliveryStatus.getStyleClass().add("cell_deliveryStatus_label_" + order.getDeliveryStatus().toString());
     }
 
     @Override
@@ -82,4 +91,6 @@ public class OrderCard extends UiPart<Region> {
         return id.getText().equals(card.id.getText())
                 && order.equals(card.order);
     }
+
+
 }

--- a/src/main/java/seedu/cakecollate/ui/OrderCard.java
+++ b/src/main/java/seedu/cakecollate/ui/OrderCard.java
@@ -8,7 +8,6 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.cakecollate.model.order.Order;
-import seedu.cakecollate.model.order.Status;
 
 /**
  * An UI component that displays information of a {@code Order}.

--- a/src/main/java/seedu/cakecollate/ui/UiManager.java
+++ b/src/main/java/seedu/cakecollate/ui/UiManager.java
@@ -43,8 +43,8 @@ public class UiManager implements Ui {
         try {
             mainWindow = new MainWindow(primaryStage, logic);
             mainWindow.show(); //This should be called before creating other UI parts
-            mainWindow.fillOrderListPanel();
             mainWindow.fillInnerParts();
+            mainWindow.fillOrderListPanel();
 
         } catch (Throwable e) {
             logger.severe(StringUtil.getDetails(e));

--- a/src/main/java/seedu/cakecollate/ui/UiManager.java
+++ b/src/main/java/seedu/cakecollate/ui/UiManager.java
@@ -44,6 +44,7 @@ public class UiManager implements Ui {
             mainWindow = new MainWindow(primaryStage, logic);
             mainWindow.show(); //This should be called before creating other UI parts
             mainWindow.fillInnerParts();
+            mainWindow.updateDeliveryStatuses();
             mainWindow.fillOrderListPanel();
 
         } catch (Throwable e) {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -138,6 +138,26 @@
     -fx-text-fill: #010504;
 }
 
+.cell_deliveryStatus_label_general {
+    -fx-text-fill: white;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 13;
+}
+
+.cell_deliveryStatus_label_UNDELIVERED {
+    -fx-background-color: #ff0000;
+}
+
+.cell_deliveryStatus_label_DELIVERED {
+    -fx-background-color: #0e6b0e;
+}
+
+.cell_deliveryStatus_label_CANCELLED {
+    -fx-background-color: #ffd300;
+}
+
 .stack-pane {
      -fx-background-color: derive(#1d1d1d, 20%);
 }

--- a/src/main/resources/view/OrderListCard.fxml
+++ b/src/main/resources/view/OrderListCard.fxml
@@ -26,6 +26,7 @@
           </minWidth>
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="deliveryStatus" text="\$first" styleClass="cell_deliveryStatus_label_general" wrapText="true" />
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" wrapText="true" />

--- a/src/test/java/seedu/cakecollate/logic/commands/DeliveryStatusCommandTest.java
+++ b/src/test/java/seedu/cakecollate/logic/commands/DeliveryStatusCommandTest.java
@@ -1,0 +1,121 @@
+package seedu.cakecollate.logic.commands;
+
+import org.junit.jupiter.api.Test;
+import seedu.cakecollate.commons.core.Messages;
+import seedu.cakecollate.commons.core.index.Index;
+import seedu.cakecollate.commons.core.index.IndexList;
+import seedu.cakecollate.model.Model;
+import seedu.cakecollate.model.ModelManager;
+import seedu.cakecollate.model.UserPrefs;
+import seedu.cakecollate.model.order.DeliveryStatus;
+import seedu.cakecollate.model.order.Order;
+import seedu.cakecollate.model.order.Status;
+import seedu.cakecollate.testutil.OrderBuilder;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.cakecollate.logic.commands.CommandTestUtil.*;
+import static seedu.cakecollate.testutil.TypicalIndexes.INDEX_FIRST_ORDER;
+import static seedu.cakecollate.testutil.TypicalIndexes.INDEX_SECOND_ORDER;
+import static seedu.cakecollate.testutil.TypicalOrders.getTypicalCakeCollate;
+
+class DeliveryStatusCommandTest {
+    private Model model = new ModelManager(getTypicalCakeCollate(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Order orderToUpdate = model.getFilteredOrderList().get(INDEX_FIRST_ORDER.getZeroBased());
+        ArrayList<Index> arrayFirstOrder = new ArrayList<Index>();
+        arrayFirstOrder.add(INDEX_FIRST_ORDER);
+        IndexList indexList = new IndexList(arrayFirstOrder);
+        DeliveryStatusCommand deliveryStatusCommand = new DeliveryStatusCommand(indexList, new DeliveryStatus());
+
+        String expectedMessage = String.format(DeliveryStatusCommand.MESSAGE_DELIVERY_STATUS_ORDER_SUCCESS,
+                String.format("\n%1$s", orderToUpdate));
+
+        ModelManager expectedModel = new ModelManager(model.getCakeCollate(), new UserPrefs());
+        expectedModel.setOrder(expectedModel.getFilteredOrderList().get(0), orderToUpdate);
+
+        assertCommandSuccess(deliveryStatusCommand, model, expectedMessage, expectedModel);
+
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredOrderList().size() + 1);
+        ArrayList<Index> array = new ArrayList<Index>();
+        array.add(outOfBoundIndex);
+        IndexList outOfBoundIndexList = new IndexList(array);
+        DeliveryStatusCommand deliveryStatusCommand = new DeliveryStatusCommand(outOfBoundIndexList, new DeliveryStatus());
+
+        assertCommandFailure(deliveryStatusCommand, model, Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        Order orderToUpdate = model.getFilteredOrderList().get(INDEX_FIRST_ORDER.getZeroBased());
+        ArrayList<Index> arrayFirstOrder = new ArrayList<Index>();
+        arrayFirstOrder.add(INDEX_FIRST_ORDER);
+        IndexList indexList = new IndexList(arrayFirstOrder);
+        DeliveryStatusCommand deliveryStatusCommand = new DeliveryStatusCommand(indexList, new DeliveryStatus());
+
+        String expectedMessage = String.format(DeliveryStatusCommand.MESSAGE_DELIVERY_STATUS_ORDER_SUCCESS,
+                String.format("\n%1$s", orderToUpdate));
+
+        ModelManager expectedModel = new ModelManager(model.getCakeCollate(), new UserPrefs());
+        expectedModel.setOrder(expectedModel.getFilteredOrderList().get(0), orderToUpdate);
+
+        assertCommandSuccess(deliveryStatusCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showOrderAtIndex(model, INDEX_FIRST_ORDER);
+
+        Index outOfBoundIndex = INDEX_SECOND_ORDER;
+        // ensures that outOfBoundIndex is still in bounds of CakeCollate list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getCakeCollate().getOrderList().size());
+        ArrayList<Index> array = new ArrayList<Index>();
+        array.add(outOfBoundIndex);
+        IndexList outOfBoundIndexList = new IndexList(array);
+        DeliveryStatusCommand deliveryStatusCommand = new DeliveryStatusCommand(outOfBoundIndexList, new DeliveryStatus());
+
+        assertCommandFailure(deliveryStatusCommand, model, Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        ArrayList<Index> arrayFirstOrder = new ArrayList<Index>();
+        arrayFirstOrder.add(INDEX_FIRST_ORDER);
+        IndexList indexListFirstOrder = new IndexList(arrayFirstOrder);
+
+        ArrayList<Index> arraySecondOrder = new ArrayList<Index>();
+        arraySecondOrder.add(INDEX_SECOND_ORDER);
+        IndexList indexListSecondOrder = new IndexList(arraySecondOrder);
+        DeliveryStatusCommand deliveryStatusFirstCommand =
+                new DeliveryStatusCommand(indexListFirstOrder, new DeliveryStatus());
+        DeliveryStatusCommand deliveryStatusSecondCommand =
+                new DeliveryStatusCommand(indexListSecondOrder, new DeliveryStatus());
+
+        // same object -> returns true
+        assertTrue(deliveryStatusFirstCommand.equals(deliveryStatusFirstCommand));
+
+        // same values -> returns true
+        ArrayList<Index> array = new ArrayList<Index>();
+        array.add(INDEX_FIRST_ORDER);
+        IndexList indexList = new IndexList(array);
+        DeliveryStatusCommand deliveryStatusFirstCommandCopy = new DeliveryStatusCommand(indexList, new DeliveryStatus());
+        assertTrue(deliveryStatusFirstCommand.equals(deliveryStatusFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deliveryStatusFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deliveryStatusFirstCommand.equals(null));
+
+        // different order -> returns false
+        assertFalse(deliveryStatusFirstCommand.equals(deliveryStatusSecondCommand));
+
+    }
+}

--- a/src/test/java/seedu/cakecollate/logic/commands/DeliveryStatusCommandTest.java
+++ b/src/test/java/seedu/cakecollate/logic/commands/DeliveryStatusCommandTest.java
@@ -1,6 +1,18 @@
 package seedu.cakecollate.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.cakecollate.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.cakecollate.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.cakecollate.logic.commands.CommandTestUtil.showOrderAtIndex;
+import static seedu.cakecollate.testutil.TypicalIndexes.INDEX_FIRST_ORDER;
+import static seedu.cakecollate.testutil.TypicalIndexes.INDEX_SECOND_ORDER;
+import static seedu.cakecollate.testutil.TypicalOrders.getTypicalCakeCollate;
+
+import java.util.ArrayList;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.cakecollate.commons.core.Messages;
 import seedu.cakecollate.commons.core.index.Index;
 import seedu.cakecollate.commons.core.index.IndexList;
@@ -9,16 +21,6 @@ import seedu.cakecollate.model.ModelManager;
 import seedu.cakecollate.model.UserPrefs;
 import seedu.cakecollate.model.order.DeliveryStatus;
 import seedu.cakecollate.model.order.Order;
-import seedu.cakecollate.model.order.Status;
-import seedu.cakecollate.testutil.OrderBuilder;
-
-import java.util.ArrayList;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static seedu.cakecollate.logic.commands.CommandTestUtil.*;
-import static seedu.cakecollate.testutil.TypicalIndexes.INDEX_FIRST_ORDER;
-import static seedu.cakecollate.testutil.TypicalIndexes.INDEX_SECOND_ORDER;
-import static seedu.cakecollate.testutil.TypicalOrders.getTypicalCakeCollate;
 
 class DeliveryStatusCommandTest {
     private Model model = new ModelManager(getTypicalCakeCollate(), new UserPrefs());
@@ -47,7 +49,8 @@ class DeliveryStatusCommandTest {
         ArrayList<Index> array = new ArrayList<Index>();
         array.add(outOfBoundIndex);
         IndexList outOfBoundIndexList = new IndexList(array);
-        DeliveryStatusCommand deliveryStatusCommand = new DeliveryStatusCommand(outOfBoundIndexList, new DeliveryStatus());
+        DeliveryStatusCommand deliveryStatusCommand =
+                new DeliveryStatusCommand(outOfBoundIndexList, new DeliveryStatus());
 
         assertCommandFailure(deliveryStatusCommand, model, Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
     }
@@ -79,7 +82,8 @@ class DeliveryStatusCommandTest {
         ArrayList<Index> array = new ArrayList<Index>();
         array.add(outOfBoundIndex);
         IndexList outOfBoundIndexList = new IndexList(array);
-        DeliveryStatusCommand deliveryStatusCommand = new DeliveryStatusCommand(outOfBoundIndexList, new DeliveryStatus());
+        DeliveryStatusCommand deliveryStatusCommand =
+                new DeliveryStatusCommand(outOfBoundIndexList, new DeliveryStatus());
 
         assertCommandFailure(deliveryStatusCommand, model, Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
     }
@@ -105,7 +109,8 @@ class DeliveryStatusCommandTest {
         ArrayList<Index> array = new ArrayList<Index>();
         array.add(INDEX_FIRST_ORDER);
         IndexList indexList = new IndexList(array);
-        DeliveryStatusCommand deliveryStatusFirstCommandCopy = new DeliveryStatusCommand(indexList, new DeliveryStatus());
+        DeliveryStatusCommand deliveryStatusFirstCommandCopy =
+                new DeliveryStatusCommand(indexList, new DeliveryStatus());
         assertTrue(deliveryStatusFirstCommand.equals(deliveryStatusFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/seedu/cakecollate/logic/parser/DeliveryStatusCommandParserTest.java
+++ b/src/test/java/seedu/cakecollate/logic/parser/DeliveryStatusCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.cakecollate.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.cakecollate.commons.core.index.Index;
+import seedu.cakecollate.commons.core.index.IndexList;
+import seedu.cakecollate.logic.commands.DeleteCommand;
+import seedu.cakecollate.logic.commands.DeliveryStatusCommand;
+import seedu.cakecollate.model.order.DeliveryStatus;
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.cakecollate.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.cakecollate.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.cakecollate.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.cakecollate.testutil.TypicalIndexes.INDEX_FIRST_ORDER;
+
+class DeliveryStatusCommandParserTest {
+    private DeliveryStatusCommandParser parser = new DeliveryStatusCommandParser(new DeliveryStatus());
+
+    @Test
+    public void parse_validArgs_returnsDeliveryStatusCommand() {
+        ArrayList<Index> arrayFirstOrder = new ArrayList<Index>();
+        arrayFirstOrder.add(INDEX_FIRST_ORDER);
+        IndexList indexList = new IndexList(arrayFirstOrder);
+        assertParseSuccess(parser, "1", new DeliveryStatusCommand(indexList, new DeliveryStatus()));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                DeliveryStatusCommand.getMessageUsage(new DeliveryStatus().toString())));
+    }
+}

--- a/src/test/java/seedu/cakecollate/logic/parser/DeliveryStatusCommandParserTest.java
+++ b/src/test/java/seedu/cakecollate/logic/parser/DeliveryStatusCommandParserTest.java
@@ -1,19 +1,18 @@
 package seedu.cakecollate.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.cakecollate.commons.core.index.Index;
-import seedu.cakecollate.commons.core.index.IndexList;
-import seedu.cakecollate.logic.commands.DeleteCommand;
-import seedu.cakecollate.logic.commands.DeliveryStatusCommand;
-import seedu.cakecollate.model.order.DeliveryStatus;
-
-import java.util.ArrayList;
-
-import static org.junit.jupiter.api.Assertions.*;
 import static seedu.cakecollate.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.cakecollate.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.cakecollate.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.cakecollate.testutil.TypicalIndexes.INDEX_FIRST_ORDER;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.cakecollate.commons.core.index.Index;
+import seedu.cakecollate.commons.core.index.IndexList;
+import seedu.cakecollate.logic.commands.DeliveryStatusCommand;
+import seedu.cakecollate.model.order.DeliveryStatus;
 
 class DeliveryStatusCommandParserTest {
     private DeliveryStatusCommandParser parser = new DeliveryStatusCommandParser(new DeliveryStatus());

--- a/src/test/java/seedu/cakecollate/storage/JsonAdaptedOrderTest.java
+++ b/src/test/java/seedu/cakecollate/storage/JsonAdaptedOrderTest.java
@@ -18,6 +18,7 @@ import seedu.cakecollate.model.order.Email;
 import seedu.cakecollate.model.order.Name;
 import seedu.cakecollate.model.order.OrderDescription;
 import seedu.cakecollate.model.order.Phone;
+import seedu.cakecollate.model.order.Status;
 
 public class JsonAdaptedOrderTest {
     private static final String INVALID_NAME = "R@chel";
@@ -39,6 +40,7 @@ public class JsonAdaptedOrderTest {
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
     private static final String VALID_DELIVERY_DATE = BENSON.getDeliveryDate().toString();
+    private static final Status VALID_DELIVERY_STATUS = BENSON.getDeliveryStatus().getDeliveryStatus();
 
     @Test
     public void toModelType_validOrderDetails_returnsOrder() throws Exception {
@@ -49,7 +51,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE);
+                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE, VALID_DELIVERY_STATUS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
     }
@@ -57,7 +59,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE);
+                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE, VALID_DELIVERY_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
     }
@@ -66,7 +68,7 @@ public class JsonAdaptedOrderTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedOrder order =
                 new JsonAdaptedOrder(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_ORDER_DESC,
-                        VALID_TAGS, VALID_DELIVERY_DATE);
+                        VALID_TAGS, VALID_DELIVERY_DATE, VALID_DELIVERY_STATUS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
     }
@@ -74,7 +76,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE);
+                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE, VALID_DELIVERY_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
     }
@@ -82,7 +84,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
-                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE);
+                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE, VALID_DELIVERY_STATUS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
     }
@@ -90,7 +92,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE);
+                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE, VALID_DELIVERY_STATUS);
 
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
@@ -99,7 +101,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE);
+                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE, VALID_DELIVERY_STATUS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
     }
@@ -107,7 +109,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE);
+                VALID_ORDER_DESC, VALID_TAGS, VALID_DELIVERY_DATE, VALID_DELIVERY_STATUS);
 
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
@@ -119,14 +121,14 @@ public class JsonAdaptedOrderTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedOrder order =
                 new JsonAdaptedOrder(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_ORDER_DESC,
-                        invalidTags, VALID_DELIVERY_DATE);
+                        invalidTags, VALID_DELIVERY_DATE, VALID_DELIVERY_STATUS);
         assertThrows(IllegalValueException.class, order::toModelType);
     }
 
     @Test
     public void toModelType_nullOrderDescription_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                null, VALID_TAGS, VALID_DELIVERY_DATE);
+                null, VALID_TAGS, VALID_DELIVERY_DATE, VALID_DELIVERY_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, OrderDescription.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
     }
@@ -136,7 +138,7 @@ public class JsonAdaptedOrderTest {
         List<JsonAdaptedOrderDescription> invalidOrderDescs = new ArrayList<>(VALID_ORDER_DESC);
         invalidOrderDescs.add(new JsonAdaptedOrderDescription(INVALID_ORDER_DESCRIPTION));
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                invalidOrderDescs, VALID_TAGS, VALID_DELIVERY_DATE);
+                invalidOrderDescs, VALID_TAGS, VALID_DELIVERY_DATE, VALID_DELIVERY_STATUS);
         assertThrows(IllegalValueException.class, order::toModelType);
     }
 
@@ -144,7 +146,7 @@ public class JsonAdaptedOrderTest {
     public void toModelType_invalidDeliveryDate_throwsIllegalValueException() {
         JsonAdaptedOrder order =
                 new JsonAdaptedOrder(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_ORDER_DESC, VALID_TAGS,
-                        INVALID_DELIVERY_DATE);
+                        INVALID_DELIVERY_DATE, VALID_DELIVERY_STATUS);
         String expectedMessage = DeliveryDate.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
     }
@@ -152,7 +154,7 @@ public class JsonAdaptedOrderTest {
     @Test
     public void toModelType_nullDeliveryDate_throwsIllegalValueException() {
         JsonAdaptedOrder order = new JsonAdaptedOrder(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_ORDER_DESC, VALID_TAGS, null);
+                VALID_ORDER_DESC, VALID_TAGS, null, VALID_DELIVERY_STATUS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, DeliveryDate.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
     }

--- a/src/test/java/seedu/cakecollate/testutil/OrderBuilder.java
+++ b/src/test/java/seedu/cakecollate/testutil/OrderBuilder.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import seedu.cakecollate.model.order.Address;
 import seedu.cakecollate.model.order.DeliveryDate;
+import seedu.cakecollate.model.order.DeliveryStatus;
 import seedu.cakecollate.model.order.Email;
 import seedu.cakecollate.model.order.Name;
 import seedu.cakecollate.model.order.Order;
@@ -32,6 +33,7 @@ public class OrderBuilder {
     private Set<OrderDescription> orderDescriptions;
     private Set<Tag> tags;
     private DeliveryDate deliveryDate;
+    private DeliveryStatus deliveryStatus;
 
     /**
      * Creates a {@code OrderBuilder} with the default details.
@@ -45,6 +47,7 @@ public class OrderBuilder {
         orderDescriptions.add(new OrderDescription(DEFAULT_ORDER_DESCRIPTION));
         tags = new HashSet<>();
         deliveryDate = new DeliveryDate(DEFAULT_DELIVERY_DATE);
+        deliveryStatus = new DeliveryStatus();
     }
 
     /**
@@ -58,6 +61,7 @@ public class OrderBuilder {
         orderDescriptions = new HashSet<>(orderToCopy.getOrderDescriptions());
         tags = new HashSet<>(orderToCopy.getTags());
         deliveryDate = orderToCopy.getDeliveryDate();
+        deliveryStatus = orderToCopy.getDeliveryStatus();
     }
 
     /**
@@ -115,8 +119,16 @@ public class OrderBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code DeliveryStatus} of the {@code Order} that we are building.
+     */
+    public OrderBuilder withDeliveryStatus() {
+        this.deliveryStatus = new DeliveryStatus();
+        return this;
+    }
+
     public Order build() {
-        return new Order(name, phone, email, address, orderDescriptions, tags, deliveryDate);
+        return new Order(name, phone, email, address, orderDescriptions, tags, deliveryDate, deliveryStatus);
     }
 
 }

--- a/src/test/java/seedu/cakecollate/testutil/TypicalOrders.java
+++ b/src/test/java/seedu/cakecollate/testutil/TypicalOrders.java
@@ -32,47 +32,48 @@ public class TypicalOrders {
     public static final Order ALICE = new OrderBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253").withOrderDescriptions("2 x Strawberry Cakes").withTags("friends")
-            .withDeliveryDate("01/01/2022").build();
+            .withDeliveryDate("01/01/2022").withDeliveryStatus().build();
     public static final Order BENSON = new OrderBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withOrderDescriptions("2 x Chocolate Cakes")
             .withTags("owesMoney", "friends")
-            .withDeliveryDate("01-01-2022").build();
+            .withDeliveryDate("01-01-2022").withDeliveryStatus().build();
     public static final Order CARL = new OrderBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withOrderDescriptions("1 Vanilla Cake")
-            .withDeliveryDate("01.01.2022").build();
+            .withDeliveryDate("01.01.2022").withDeliveryStatus().build();
     public static final Order DANIEL = new OrderBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street")
+            .withEmail("cornelia@example.com").withDeliveryStatus().withAddress("10th street")
             .withOrderDescriptions("1 Chocolate Chip Muffin").withTags("friends")
-            .withDeliveryDate("01 Jan 2022").build();
+            .withDeliveryDate("01 Jan 2022").withDeliveryStatus().build();
     public static final Order ELLE = new OrderBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave")
             .withOrderDescriptions("1 Raisins Cake Thing", "1 x Blackforest cake", "1 x Vanilla Cake")
-            .withDeliveryDate("31/12/2022").build();
+            .withDeliveryDate("31/12/2022").withDeliveryStatus().build();
     public static final Order FIONA = new OrderBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo")
-            .withOrderDescriptions("2 x Vanilla cakes").withDeliveryDate("28-02-2022").build();
+            .withOrderDescriptions("2 x Vanilla cakes").withDeliveryDate("28-02-2022").withDeliveryStatus().build();
     public static final Order GEORGE = new OrderBuilder().withName("George Best").withPhone("9482442")
             .withEmail("anna@example.com").withAddress("4th street")
-            .withOrderDescriptions("2 lava cakes").withDeliveryDate("06.03.2022").build();
+            .withOrderDescriptions("2 lava cakes").withDeliveryDate("06.03.2022").withDeliveryStatus().build();
 
     // Manually added
     public static final Order HOON = new OrderBuilder().withName("Hoon Meier").withPhone("8482424")
             .withEmail("stefan@example.com").withAddress("little india").withOrderDescriptions("2 jelly hearts")
-            .withOrderDescriptions("1 mango cake").withDeliveryDate("01/01/2022").build();
+            .withOrderDescriptions("1 mango cake").withDeliveryDate("01/01/2022").withDeliveryStatus().build();
     public static final Order IDA = new OrderBuilder().withName("Ida Mueller").withPhone("8482131")
             .withEmail("hans@example.com").withAddress("chicago ave").withOrderDescriptions("a mango cake")
-            .withOrderDescriptions("vanilla with lemon zest").withDeliveryDate("01/01/2022").build();
+            .withOrderDescriptions("vanilla with lemon zest").withDeliveryDate("01/01/2022")
+            .withDeliveryStatus().build();
 
     // Manually added - Order's details found in {@code CommandTestUtil}
     public static final Order AMY = new OrderBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withOrderDescriptions(VALID_CHOCOLATE_ORDER)
-            .withTags(VALID_TAG_FRIEND).withDeliveryDate(VALID_DELIVERY_DATE_AMY).build();
+            .withTags(VALID_TAG_FRIEND).withDeliveryDate(VALID_DELIVERY_DATE_AMY).withDeliveryStatus().build();
     public static final Order BOB = new OrderBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withOrderDescriptions(VALID_BERRY_ORDER)
             .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withDeliveryDate(VALID_DELIVERY_DATE_BOB)
-            .build();
+            .withDeliveryStatus().build();
 
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER


### PR DESCRIPTION
- If an add command is used to enter an order, the delivery status is automatically set to undelivered.
- If the current date exceeds the delivery date, the delivery status is automatically set to delivered.
- The user can modify the delivery status using the following commands:
    1) undelivered *index list* (e.g. undelivered 1 2 3) -> sets the delivery status of orders 1, 2, and 3 to undelivered
    2) delivered *index list* (e.g. delivered 1 2 3) -> sets the delivery status of orders 1, 2, and 3 to delivered.
    3) cancelled *index list* (e.g. cancelled 1 2 3) -> sets the delivery status of orders 1, 2, and 3 to cancelled.
- More statuses can be added to the enum if necessary.
- Updated the main window such that if a valid non-help command is entered while in the help window, the program automatically shifts back to the main window.
- Tests only added for deliveryStatusCommand and deliveryStatusParserCommand. As the user does not enter the delivery status when using the add command, it is impossible to get invalid inputs so not sure how to test the delivery status.
