### PR TITLE
Updated DeliveryDate

### DIFF
--- a/src/main/java/seedu/cakecollate/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/ParserUtil.java
@@ -184,8 +184,13 @@ public class ParserUtil {
     public static DeliveryDate parseDeliveryDate(String deliveryDate) throws ParseException {
         requireNonNull(deliveryDate);
         String trimmedDeliveryDate = deliveryDate.trim();
-        if (!DeliveryDate.isValidDeliveryDate(trimmedDeliveryDate)) {
-            throw new ParseException(DeliveryDate.MESSAGE_CONSTRAINTS);
+        if (!DeliveryDate.isValidFormat(trimmedDeliveryDate)) {
+            System.out.println("not valid format");
+            throw new ParseException(DeliveryDate.MESSAGE_CONSTRAINTS_FORMAT);
+        }
+        if (!DeliveryDate.isXDaysLater(trimmedDeliveryDate, 0L)) {
+            System.out.println("not future date");
+            throw new ParseException(String.format(DeliveryDate.MESSAGE_CONSTRAINTS_VALUE, trimmedDeliveryDate));
         }
         return new DeliveryDate(trimmedDeliveryDate);
     }

--- a/src/main/java/seedu/cakecollate/storage/JsonAdaptedOrder.java
+++ b/src/main/java/seedu/cakecollate/storage/JsonAdaptedOrder.java
@@ -132,8 +132,8 @@ class JsonAdaptedOrder {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     DeliveryDate.class.getSimpleName()));
         }
-        if (!DeliveryDate.isValidDeliveryDate(deliveryDate)) {
-            throw new IllegalValueException(DeliveryDate.MESSAGE_CONSTRAINTS);
+        if (!DeliveryDate.isValidFormat(deliveryDate)) {
+            throw new IllegalValueException(DeliveryDate.MESSAGE_CONSTRAINTS_FORMAT);
         }
         final DeliveryDate modelDeliveryDate = new DeliveryDate(deliveryDate);
 

--- a/src/test/java/seedu/cakecollate/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/cakecollate/logic/commands/CommandTestUtil.java
@@ -77,7 +77,8 @@ public class CommandTestUtil {
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_ORDER_DESC = " " + PREFIX_ORDER_DESCRIPTION; // empty string not allowed
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
-    public static final String INVALID_DELIVERY_DATE_DESC = " " + PREFIX_DATE + "2021/03/03"; // invalid format
+    public static final String INVALID_DELIVERY_DATE_DESC1 = " " + PREFIX_DATE + "2021/03/03"; // invalid format
+    public static final String INVALID_DELIVERY_DATE_DESC2 = " " + PREFIX_DATE + "01/01/2000"; // invalid value
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/cakecollate/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/cakecollate/logic/parser/AddCommandParserTest.java
@@ -8,7 +8,7 @@ import static seedu.cakecollate.logic.commands.CommandTestUtil.DELIVERY_DATE_DES
 import static seedu.cakecollate.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.cakecollate.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.cakecollate.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
-import static seedu.cakecollate.logic.commands.CommandTestUtil.INVALID_DELIVERY_DATE_DESC;
+import static seedu.cakecollate.logic.commands.CommandTestUtil.INVALID_DELIVERY_DATE_DESC1;
 import static seedu.cakecollate.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.cakecollate.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.cakecollate.logic.commands.CommandTestUtil.INVALID_ORDER_DESC;
@@ -174,8 +174,8 @@ public class AddCommandParserTest {
 
         // invalid delivery date
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + ORDER_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + INVALID_DELIVERY_DATE_DESC,
-                DeliveryDate.MESSAGE_CONSTRAINTS);
+                + ORDER_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + INVALID_DELIVERY_DATE_DESC1,
+                DeliveryDate.MESSAGE_CONSTRAINTS_FORMAT);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC

--- a/src/test/java/seedu/cakecollate/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/cakecollate/logic/parser/EditCommandParserTest.java
@@ -8,7 +8,7 @@ import static seedu.cakecollate.logic.commands.CommandTestUtil.DELIVERY_DATE_DES
 import static seedu.cakecollate.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.cakecollate.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.cakecollate.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
-import static seedu.cakecollate.logic.commands.CommandTestUtil.INVALID_DELIVERY_DATE_DESC;
+import static seedu.cakecollate.logic.commands.CommandTestUtil.INVALID_DELIVERY_DATE_DESC2;
 import static seedu.cakecollate.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.cakecollate.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.cakecollate.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
@@ -99,8 +99,8 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
         assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid cakecollate
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
-        assertParseFailure(parser, "1" + INVALID_DELIVERY_DATE_DESC,
-                DeliveryDate.MESSAGE_CONSTRAINTS); // invalid delivery date
+        assertParseFailure(parser, "1" + INVALID_DELIVERY_DATE_DESC2,
+                String.format(DeliveryDate.MESSAGE_CONSTRAINTS_VALUE, "01/01/2000")); // invalid delivery date
 
         // invalid phone followed by valid email
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/cakecollate/model/order/DeliveryDateTest.java
+++ b/src/test/java/seedu/cakecollate/model/order/DeliveryDateTest.java
@@ -41,26 +41,42 @@ public class DeliveryDateTest {
     @Test
     public void isValidDeliveryDate() {
         // null delivery date
-        assertThrows(NullPointerException.class, () -> DeliveryDate.isValidDeliveryDate(null));
+        assertThrows(NullPointerException.class, () -> DeliveryDate.isValidFormat(null));
 
-        // invalid addresses
-        assertFalse(DeliveryDate.isValidDeliveryDate("01/13/2022")); // invalid month
-        assertFalse(DeliveryDate.isValidDeliveryDate("32/01/2022")); // invalid day
-        assertFalse(DeliveryDate.isValidDeliveryDate("01/01/202020")); // invalid year
-        assertFalse(DeliveryDate.isValidDeliveryDate("01,01,2022")); // invalid delimiter
-        assertFalse(DeliveryDate.isValidDeliveryDate("01:01:2022")); // invalid delimiter
-        assertFalse(DeliveryDate.isValidDeliveryDate("01/01-2022")); // inconsistent delimiter
-        assertFalse(DeliveryDate.isValidDeliveryDate("2022/12/31")); // invalid format
-        // less than 3 working days
-        assertFalse(DeliveryDate.isValidDeliveryDate(LocalDate.now().plusDays(2L).toString()));
+        // invalid delivery dates
+        assertFalse(DeliveryDate.isValidFormat("01/13/2022")); // invalid month
+        assertFalse(DeliveryDate.isValidFormat("32/01/2022")); // invalid day
+        assertFalse(DeliveryDate.isValidFormat("01/01/202020")); // invalid year
+        assertFalse(DeliveryDate.isValidFormat("01,01,2022")); // invalid delimiter
+        assertFalse(DeliveryDate.isValidFormat("01:01:2022")); // invalid delimiter
+        assertFalse(DeliveryDate.isValidFormat("01/01-2022")); // inconsistent delimiter
+        assertFalse(DeliveryDate.isValidFormat("2022/12/31")); // invalid format
+        assertFalse(DeliveryDate.isValidFormat(LocalDate.now().toString())); // Invalid in-build LocalDate format
 
-        // valid addresses
-        assertTrue(DeliveryDate.isValidDeliveryDate("02/02/2022"));
-        assertTrue(DeliveryDate.isValidDeliveryDate("02-02-2022"));
-        assertTrue(DeliveryDate.isValidDeliveryDate("02.02.2022"));
-        assertTrue(DeliveryDate.isValidDeliveryDate("02 Feb 2022"));
+        // valid delivery dates
+        assertTrue(DeliveryDate.isValidFormat("02/02/2022"));
+        assertTrue(DeliveryDate.isValidFormat("02-02-2022"));
+        assertTrue(DeliveryDate.isValidFormat("02.02.2022"));
+        assertTrue(DeliveryDate.isValidFormat("02 Feb 2022"));
         DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("[dd/MM/yyyy]");
         // 3 working days from current date
-        assertTrue(DeliveryDate.isValidDeliveryDate(dateFormat.format(LocalDate.now().plusDays(3L))));
+        assertTrue(DeliveryDate.isValidFormat(dateFormat.format(LocalDate.now().plusDays(3L))));
+    }
+
+    @Test
+    public void isXDaysLater() {
+        String yesterday = DateTimeFormatter.ofPattern("[dd/MM/yyyy]").format(LocalDate.now().plusDays(-1L));
+        String today = DateTimeFormatter.ofPattern("[dd/MM/yyyy]").format(LocalDate.now());
+        String tomorrow = DateTimeFormatter.ofPattern("[dd/MM/yyyy]").format(LocalDate.now().plusDays(1L));
+        // isValidFormat should be called before isXDaysLater
+        assertFalse(DeliveryDate.isValidFormat("2020/13/40") && DeliveryDate.isXDaysLater(today, 0L));
+
+        // date is in the past
+        assertFalse(DeliveryDate.isValidFormat(yesterday) && DeliveryDate.isXDaysLater(yesterday, 0L));
+
+        // date is today or in the future
+        assertTrue(DeliveryDate.isValidFormat(today) && DeliveryDate.isXDaysLater(today, 0L));
+        assertTrue(DeliveryDate.isValidFormat(tomorrow) && DeliveryDate.isXDaysLater(tomorrow, 0L));
+        assertTrue(DeliveryDate.isValidFormat(tomorrow) && DeliveryDate.isXDaysLater(tomorrow, 1L));
     }
 }

--- a/src/test/java/seedu/cakecollate/storage/JsonAdaptedOrderTest.java
+++ b/src/test/java/seedu/cakecollate/storage/JsonAdaptedOrderTest.java
@@ -148,7 +148,7 @@ public class JsonAdaptedOrderTest {
         JsonAdaptedOrder order =
                 new JsonAdaptedOrder(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_ORDER_DESC, VALID_TAGS,
                         INVALID_DELIVERY_DATE, VALID_DELIVERY_STATUS, VALID_REQUEST);
-        String expectedMessage = DeliveryDate.MESSAGE_CONSTRAINTS;
+        String expectedMessage = DeliveryDate.MESSAGE_CONSTRAINTS_FORMAT;
         assertThrows(IllegalValueException.class, expectedMessage, order::toModelType);
     }
 


### PR DESCRIPTION
- 3 working days validation removed during instantiation
- "future date" validation is done during parsing of user input through edit and add command (using parserutil)
- isXDaysLater is edited for extensibility
- different message constraints is displayed according to type of exception raised (format vs value)
Fixes #103 