### PR TITLE
Size limit for fields

### DIFF
--- a/src/main/java/seedu/cakecollate/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/ParserUtil.java
@@ -27,6 +27,12 @@ import seedu.cakecollate.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final int PHONE_LENGTH = 20;
+    public static final int TAG_LENGTH = 30;
+    public static final int ADDRESS_LENGTH = 255;
+    public static final int EMAIL_LENGTH = 255;
+    public static final int INTEGER_LENGTH = 10;
+    public static final int NAME_LENGTH = 80;
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -69,6 +75,12 @@ public class ParserUtil {
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
         String trimmedName = name.trim();
+        if (trimmedName.isEmpty()) {
+            throw new ParseException(Name.MESSAGE_EMPTY);
+        }
+        if (trimmedName.length() > NAME_LENGTH) {
+            throw new ParseException(Name.MESSAGE_OVERFLOW);
+        }
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
@@ -84,6 +96,12 @@ public class ParserUtil {
     public static Phone parsePhone(String phone) throws ParseException {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
+        if (trimmedPhone.isEmpty()) {
+            throw new ParseException(Phone.MESSAGE_EMPTY);
+        }
+        if (trimmedPhone.length() > PHONE_LENGTH) {
+            throw new ParseException(Phone.MESSAGE_OVERFLOW);
+        }
         if (!Phone.isValidPhone(trimmedPhone)) {
             throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
         }
@@ -99,6 +117,9 @@ public class ParserUtil {
     public static Address parseAddress(String address) throws ParseException {
         requireNonNull(address);
         String trimmedAddress = address.trim();
+        if (trimmedAddress.isEmpty()) {
+            throw new ParseException(Address.MESSAGE_EMPTY);
+        }
         if (!Address.isValidAddress(trimmedAddress)) {
             throw new ParseException(Address.MESSAGE_CONSTRAINTS);
         }
@@ -114,6 +135,9 @@ public class ParserUtil {
     public static Email parseEmail(String email) throws ParseException {
         requireNonNull(email);
         String trimmedEmail = email.trim();
+        if (trimmedEmail.isEmpty()) {
+            throw new ParseException(Email.MESSAGE_EMPTY);
+        }
         if (!Email.isValidEmail(trimmedEmail)) {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
         }
@@ -159,6 +183,9 @@ public class ParserUtil {
     public static Tag parseTag(String tag) throws ParseException {
         requireNonNull(tag);
         String trimmedTag = tag.trim();
+        if (trimmedTag.length() > TAG_LENGTH) {
+            throw new ParseException(Tag.MESSAGE_OVERFLOW);
+        }
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/cakecollate/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/ParserUtil.java
@@ -29,8 +29,7 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final int PHONE_LENGTH = 20;
     public static final int TAG_LENGTH = 30;
-    public static final int ADDRESS_LENGTH = 255;
-    public static final int EMAIL_LENGTH = 255;
+
     public static final int INTEGER_LENGTH = 10;
     public static final int NAME_LENGTH = 80;
 
@@ -153,7 +152,6 @@ public class ParserUtil {
     public static OrderDescription parseOrderDescription(String orderDescription) throws ParseException {
         requireNonNull(orderDescription);
         String trimmedOrderDescription = orderDescription.trim();
-
         if (!OrderDescription.isValidOrderDescription(trimmedOrderDescription)) {
             throw new ParseException(OrderDescription.MESSAGE_CONSTRAINTS);
         }
@@ -213,6 +211,9 @@ public class ParserUtil {
     public static DeliveryDate parseDeliveryDate(String deliveryDate) throws ParseException {
         requireNonNull(deliveryDate);
         String trimmedDeliveryDate = deliveryDate.trim();
+        if (trimmedDeliveryDate.isEmpty()) {
+            throw new ParseException(DeliveryDate.MESSAGE_EMPTY);
+        }
         if (!DeliveryDate.isValidFormat(trimmedDeliveryDate)) {
             System.out.println("not valid format");
             throw new ParseException(DeliveryDate.MESSAGE_CONSTRAINTS_FORMAT);

--- a/src/main/java/seedu/cakecollate/model/order/Address.java
+++ b/src/main/java/seedu/cakecollate/model/order/Address.java
@@ -10,7 +10,7 @@ import static seedu.cakecollate.commons.util.AppUtil.checkArgument;
 public class Address {
 
     public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
-
+    public static final String MESSAGE_EMPTY = "Address cannot be blank.";
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.

--- a/src/main/java/seedu/cakecollate/model/order/DeliveryDate.java
+++ b/src/main/java/seedu/cakecollate/model/order/DeliveryDate.java
@@ -15,6 +15,7 @@ import java.time.format.DateTimeParseException;
  */
 public class DeliveryDate implements Comparable<DeliveryDate> {
 
+    public static final String MESSAGE_EMPTY = "Delivery date cannot be blank.";
     public static final String MESSAGE_CONSTRAINTS_FORMAT =
             "Delivery date should be of the format dd/mm/yyyy, dd-mm-yyyy, "
             + "dd.mm.yyyy or dd MMM yyyy and adhere to the following constraints:\n"

--- a/src/main/java/seedu/cakecollate/model/order/Email.java
+++ b/src/main/java/seedu/cakecollate/model/order/Email.java
@@ -9,6 +9,7 @@ import static seedu.cakecollate.commons.util.AppUtil.checkArgument;
  */
 public class Email {
 
+    public static final String MESSAGE_EMPTY = "Email cannot be blank.";
     private static final String SPECIAL_CHARACTERS = "!#$%&'*+/=?`{|}~^.-";
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"

--- a/src/main/java/seedu/cakecollate/model/order/Name.java
+++ b/src/main/java/seedu/cakecollate/model/order/Name.java
@@ -9,9 +9,9 @@ import static seedu.cakecollate.commons.util.AppUtil.checkArgument;
  */
 public class Name {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
-
+    public static final String MESSAGE_CONSTRAINTS = "Names should only contain alphanumeric characters and spaces.";
+    public static final String MESSAGE_EMPTY = "Name cannot be blank.";
+    public static final String MESSAGE_OVERFLOW = "Name has a size limit of 80 characters.";
     /*
      * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.

--- a/src/main/java/seedu/cakecollate/model/order/Phone.java
+++ b/src/main/java/seedu/cakecollate/model/order/Phone.java
@@ -12,6 +12,8 @@ public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Phone numbers should only contain numbers, and it should be at least 3 digits long";
+    public static final String MESSAGE_EMPTY = "Phone number cannot be blank.";
+    public static final String MESSAGE_OVERFLOW = "Phone has a size limit of 20 digits.";
     public static final String VALIDATION_REGEX = "\\d{3,}";
     public final String value;
 

--- a/src/main/java/seedu/cakecollate/model/tag/Tag.java
+++ b/src/main/java/seedu/cakecollate/model/tag/Tag.java
@@ -10,6 +10,7 @@ import static seedu.cakecollate.commons.util.AppUtil.checkArgument;
 public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_OVERFLOW = "Tags have a size limit of 30 characters.";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;

--- a/src/main/resources/view/OrderCard.fxml
+++ b/src/main/resources/view/OrderCard.fxml
@@ -27,7 +27,6 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
         <Label fx:id="deliveryStatus" text="\$first" styleClass="cell_deliveryStatus_label_general" wrapText="true" />
-        <Label fx:id="request" styleClass="cell_request_label" text="\$request" wrapText="true"/>
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" wrapText="true" />
@@ -35,6 +34,7 @@
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true" />
       <FlowPane fx:id="orderDescriptions" />
       <Label fx:id="deliveryDate" styleClass="cell_small_label" text="\$deliveryDate" wrapText="true" />
+      <Label fx:id="request" styleClass="cell_request_label" text="\$request" wrapText="true"/>
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/cakecollate/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/cakecollate/logic/parser/AddCommandParserTest.java
@@ -191,10 +191,10 @@ public class AddCommandParserTest {
                         + ORDER_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + DELIVERY_DATE_DESC_BOB,
                 Email.MESSAGE_CONSTRAINTS);
 
-        // invalid cakecollate
+        // invalid address
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
                         + ORDER_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND + DELIVERY_DATE_DESC_BOB,
-                Address.MESSAGE_CONSTRAINTS);
+                Address.MESSAGE_EMPTY);
 
         // invalid order description
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB

--- a/src/test/java/seedu/cakecollate/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/cakecollate/logic/parser/EditCommandParserTest.java
@@ -97,7 +97,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid cakecollate
+        assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_EMPTY); // invalid address
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
         assertParseFailure(parser, "1" + INVALID_DELIVERY_DATE_DESC2,
                 String.format(DeliveryDate.MESSAGE_CONSTRAINTS_VALUE, "01/01/2000")); // invalid delivery date


### PR DESCRIPTION
1. Name now has a size limit of 80
2. Phone now has a size limit of 20
3. Tags now have a size limit of 30
4. Order descriptions, Addresses and emails, requests have no size limits
5. When field is empty for DD, Phone, Name, Email, Address error thrown is [field] cannot be empty.