### PR TITLE
Fixing 32 bit int bug

### DIFF
--- a/src/main/java/seedu/cakecollate/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/DeleteCommandParser.java
@@ -2,6 +2,7 @@ package seedu.cakecollate.logic.parser;
 
 import static seedu.cakecollate.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import seedu.cakecollate.commons.core.Messages;
 import seedu.cakecollate.commons.core.index.IndexList;
 import seedu.cakecollate.logic.commands.DeleteCommand;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
@@ -17,13 +18,18 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+        boolean allDigitsAndLengthMoreThanTen = false;
         try {
+            allDigitsAndLengthMoreThanTen = args.trim().chars().allMatch(Character::isDigit)
+                    && args.length() > ParserUtil.INTEGER_LENGTH;
             IndexList indexList = ParserUtil.parseIndexList(args);
             return new DeleteCommand(indexList);
         } catch (ParseException pe) {
+            if (allDigitsAndLengthMoreThanTen) {
+                throw new ParseException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+            }
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
         }
     }
-
 }

--- a/src/main/java/seedu/cakecollate/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/EditCommandParser.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
+import seedu.cakecollate.commons.core.Messages;
 import seedu.cakecollate.commons.core.index.Index;
 import seedu.cakecollate.logic.commands.EditCommand;
 import seedu.cakecollate.logic.commands.EditCommand.EditOrderDescriptor;
@@ -40,10 +41,17 @@ public class EditCommandParser implements Parser<EditCommand> {
                         PREFIX_ORDER_DESCRIPTION, PREFIX_TAG, PREFIX_DATE, PREFIX_REQUEST);
 
         Index index;
-
+        String preamble;
+        boolean allDigitsAndLengthMoreThanTen = false;
         try {
+            preamble = argMultimap.getPreamble();
+            allDigitsAndLengthMoreThanTen = preamble.chars().allMatch(Character::isDigit)
+                    && preamble.length() > ParserUtil.INTEGER_LENGTH;
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
+            if (allDigitsAndLengthMoreThanTen) {
+                throw new ParseException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+            }
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 

--- a/src/main/java/seedu/cakecollate/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/ParserUtil.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.cakecollate.commons.core.Messages;
 import seedu.cakecollate.commons.core.index.Index;
 import seedu.cakecollate.commons.core.index.IndexList;
 import seedu.cakecollate.commons.util.StringUtil;
@@ -29,7 +30,6 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final int PHONE_LENGTH = 20;
     public static final int TAG_LENGTH = 30;
-
     public static final int INTEGER_LENGTH = 10;
     public static final int NAME_LENGTH = 80;
 
@@ -40,6 +40,9 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
+        if (trimmedIndex.length() > INTEGER_LENGTH) {
+            throw new ParseException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+        }
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }

--- a/src/main/java/seedu/cakecollate/logic/parser/RequestCommandParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/RequestCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.cakecollate.commons.core.Messages.MESSAGE_INVALID_COMMAND_FO
 import static seedu.cakecollate.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.cakecollate.logic.parser.CliSyntax.PREFIX_REQUEST;
 
+import seedu.cakecollate.commons.core.Messages;
 import seedu.cakecollate.commons.core.index.Index;
 import seedu.cakecollate.commons.exceptions.IllegalValueException;
 import seedu.cakecollate.logic.commands.RequestCommand;
@@ -23,9 +24,17 @@ public class RequestCommandParser implements Parser<RequestCommand> {
                 PREFIX_REQUEST);
 
         Index index;
+        String preamble;
+        boolean allDigitsAndLengthMoreThanTen = false;
         try {
+            preamble = argMultimap.getPreamble();
+            allDigitsAndLengthMoreThanTen = preamble.chars().allMatch(Character::isDigit)
+                    && preamble.length() > ParserUtil.INTEGER_LENGTH;
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (IllegalValueException ive) {
+            if (allDigitsAndLengthMoreThanTen) {
+                throw new ParseException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+            }
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     RequestCommand.MESSAGE_USAGE), ive);
         }

--- a/src/test/java/seedu/cakecollate/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/cakecollate/logic/parser/ParserUtilTest.java
@@ -2,7 +2,6 @@ package seedu.cakecollate.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.cakecollate.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.cakecollate.testutil.Assert.assertThrows;
 import static seedu.cakecollate.testutil.TypicalIndexes.INDEX_FIRST_ORDER;
 
@@ -13,6 +12,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.cakecollate.commons.core.Messages;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
 import seedu.cakecollate.model.order.Address;
 import seedu.cakecollate.model.order.DeliveryDate;
@@ -50,7 +50,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
+        assertThrows(ParseException.class, Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX, ()
             -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
     }
 


### PR DESCRIPTION
Fixes #165 

- currently working for commands that only take one index eg, `request 10000000000000000000` delete `100000000000000000`
- does not work for commands that take more than 1 index eg `delete 11000000000000000 1 1`
- add tests for big strings