### PR TITLE
Fix int 32bit bug. (more efficient)

### DIFF
--- a/src/main/java/seedu/cakecollate/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/DeleteCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.cakecollate.commons.core.Messages.MESSAGE_INVALID_COMMAND_FO
 
 import seedu.cakecollate.commons.core.index.IndexList;
 import seedu.cakecollate.logic.commands.DeleteCommand;
+import seedu.cakecollate.logic.parser.exceptions.IndexOutOfBoundsException;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
 
 /**
@@ -20,6 +21,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         try {
             IndexList indexList = ParserUtil.parseIndexList(args);
             return new DeleteCommand(indexList);
+        } catch (IndexOutOfBoundsException pe) {
+            throw new IndexOutOfBoundsException(pe.getMessage());
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/cakecollate/logic/parser/DeleteOrderItemCommandParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/DeleteOrderItemCommandParser.java
@@ -2,8 +2,10 @@ package seedu.cakecollate.logic.parser;
 
 import static seedu.cakecollate.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import seedu.cakecollate.commons.core.Messages;
 import seedu.cakecollate.commons.core.index.IndexList;
 import seedu.cakecollate.logic.commands.DeleteOrderItemCommand;
+import seedu.cakecollate.logic.parser.exceptions.IndexOutOfBoundsException;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
 
 /**
@@ -21,6 +23,8 @@ public class DeleteOrderItemCommandParser implements Parser<DeleteOrderItemComma
         try {
             IndexList indexList = ParserUtil.parseIndexList(args);
             return new DeleteOrderItemCommand(indexList);
+        } catch (IndexOutOfBoundsException pe) {
+            throw new IndexOutOfBoundsException(Messages.MESSAGE_INVALID_ORDER_ITEM_INDEX);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteOrderItemCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/cakecollate/logic/parser/DeliveryStatusCommandParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/DeliveryStatusCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.cakecollate.commons.core.Messages.MESSAGE_INVALID_COMMAND_FO
 
 import seedu.cakecollate.commons.core.index.IndexList;
 import seedu.cakecollate.logic.commands.DeliveryStatusCommand;
+import seedu.cakecollate.logic.parser.exceptions.IndexOutOfBoundsException;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
 import seedu.cakecollate.model.order.DeliveryStatus;
 
@@ -25,6 +26,8 @@ public class DeliveryStatusCommandParser implements Parser<DeliveryStatusCommand
             assert status != null;
             IndexList indexList = ParserUtil.parseIndexList(args);
             return new DeliveryStatusCommand(indexList, status);
+        } catch (IndexOutOfBoundsException pe) {
+            throw new IndexOutOfBoundsException(pe.getMessage());
         } catch (ParseException exception) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     DeliveryStatusCommand.getMessageUsage(status.toString())), exception);

--- a/src/main/java/seedu/cakecollate/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/EditCommandParser.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import seedu.cakecollate.commons.core.index.Index;
 import seedu.cakecollate.logic.commands.EditCommand;
 import seedu.cakecollate.logic.commands.EditCommand.EditOrderDescriptor;
+import seedu.cakecollate.logic.parser.exceptions.IndexOutOfBoundsException;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
 import seedu.cakecollate.model.order.OrderDescription;
 import seedu.cakecollate.model.tag.Tag;
@@ -43,6 +44,8 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IndexOutOfBoundsException pe) {
+            throw new IndexOutOfBoundsException(pe.getMessage());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }

--- a/src/main/java/seedu/cakecollate/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/ParserUtil.java
@@ -7,9 +7,11 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.cakecollate.commons.core.Messages;
 import seedu.cakecollate.commons.core.index.Index;
 import seedu.cakecollate.commons.core.index.IndexList;
 import seedu.cakecollate.commons.util.StringUtil;
+import seedu.cakecollate.logic.parser.exceptions.IndexOutOfBoundsException;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
 import seedu.cakecollate.model.order.Address;
 import seedu.cakecollate.model.order.DeliveryDate;
@@ -40,6 +42,12 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
+        boolean allDigits = oneBasedIndex.chars().allMatch(Character::isDigit);
+        boolean lengthMoreThanTen = oneBasedIndex.length() > INTEGER_LENGTH;
+        boolean allDigitsAndLengthMoreThanTen = allDigits && lengthMoreThanTen;
+        if (allDigitsAndLengthMoreThanTen) {
+            throw new IndexOutOfBoundsException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
+        }
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }

--- a/src/main/java/seedu/cakecollate/logic/parser/RequestCommandParser.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/RequestCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.cakecollate.logic.parser.CliSyntax.PREFIX_REQUEST;
 import seedu.cakecollate.commons.core.index.Index;
 import seedu.cakecollate.commons.exceptions.IllegalValueException;
 import seedu.cakecollate.logic.commands.RequestCommand;
+import seedu.cakecollate.logic.parser.exceptions.IndexOutOfBoundsException;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
 import seedu.cakecollate.model.order.Request;
 
@@ -25,6 +26,8 @@ public class RequestCommandParser implements Parser<RequestCommand> {
         Index index;
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IndexOutOfBoundsException pe) {
+            throw new IndexOutOfBoundsException(pe.getMessage());
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     RequestCommand.MESSAGE_USAGE), ive);

--- a/src/main/java/seedu/cakecollate/logic/parser/exceptions/IndexOutOfBoundsException.java
+++ b/src/main/java/seedu/cakecollate/logic/parser/exceptions/IndexOutOfBoundsException.java
@@ -1,0 +1,12 @@
+package seedu.cakecollate.logic.parser.exceptions;
+
+
+/**
+ * Represents a parse error encountered by a parser, when the index provided is an integer above 32bits.
+ */
+public class IndexOutOfBoundsException extends ParseException {
+
+    public IndexOutOfBoundsException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/seedu/cakecollate/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/cakecollate/logic/parser/ParserUtilTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.cakecollate.commons.core.Messages;
 import seedu.cakecollate.logic.parser.exceptions.ParseException;
 import seedu.cakecollate.model.order.Address;
 import seedu.cakecollate.model.order.DeliveryDate;
@@ -46,12 +47,15 @@ public class ParserUtilTest {
     @Test
     public void parseIndex_invalidInput_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseIndex("10 a"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndex("10aaaaa111111111111a"));
     }
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
             -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+        assertThrows(ParseException.class, Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX, ()
+            -> ParserUtil.parseIndex("111111111111111111111111111111111"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #165 

1. when inputting indexes over 32bits, the correct exception is now shown. eg, delete 100000000000000
2. works for multiple indexes eg delete 1000000000000000000 11111111111111111 