### PR TITLE
add defensive programming for request command

### DIFF
--- a/src/main/java/seedu/cakecollate/logic/commands/RequestCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/RequestCommand.java
@@ -75,6 +75,7 @@ public class RequestCommand extends Command {
     private String generateSuccessMessage(Order editedOrder, Order orderToEdit) {
         boolean isEmptyRequest = request.isRequestEmpty();
         boolean isOrderRequestCurrentlyEmpty = orderToEdit.getRequest().isRequestEmpty;
+
         if (isOrderRequestCurrentlyEmpty && isEmptyRequest) {
             return String.format(MESSAGE_DELETE_REQUEST_SUCCESS_EMPTY);
         }


### PR DESCRIPTION
1.  if a request is already empty, tell user it is already empty instead of saying that it's removed.

edit: dint realised this was already added.