### PR TITLE
Fix errors in delete command and deleteItem command caused due to repeated indices

### DIFF
--- a/src/main/java/seedu/cakecollate/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/DeleteCommand.java
@@ -56,7 +56,12 @@ public class DeleteCommand extends Command {
             }
 
             Order orderToDelete = lastShownList.get(targetIndex.getZeroBased());
-            ordersToDelete.add(orderToDelete);
+            if (!ordersToDelete.contains(orderToDelete)) {
+                ordersToDelete.add(orderToDelete);
+            }
+        }
+
+        for (Order orderToDelete:ordersToDelete) {
             model.deleteOrder(orderToDelete);
         }
 

--- a/src/main/java/seedu/cakecollate/logic/commands/DeleteOrderItemCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/DeleteOrderItemCommand.java
@@ -10,7 +10,6 @@ import seedu.cakecollate.commons.core.index.Index;
 import seedu.cakecollate.commons.core.index.IndexList;
 import seedu.cakecollate.logic.commands.exceptions.CommandException;
 import seedu.cakecollate.model.Model;
-import seedu.cakecollate.model.order.Order;
 import seedu.cakecollate.model.orderitem.OrderItem;
 
 /**

--- a/src/main/java/seedu/cakecollate/logic/commands/DeleteOrderItemCommand.java
+++ b/src/main/java/seedu/cakecollate/logic/commands/DeleteOrderItemCommand.java
@@ -10,6 +10,7 @@ import seedu.cakecollate.commons.core.index.Index;
 import seedu.cakecollate.commons.core.index.IndexList;
 import seedu.cakecollate.logic.commands.exceptions.CommandException;
 import seedu.cakecollate.model.Model;
+import seedu.cakecollate.model.order.Order;
 import seedu.cakecollate.model.orderitem.OrderItem;
 
 /**
@@ -54,12 +55,14 @@ public class DeleteOrderItemCommand extends Command {
             if (targetIndex.getZeroBased() >= lastShownList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
             }
-
             OrderItem orderItemToDelete = lastShownList.get(targetIndex.getZeroBased());
-            orderItemsToDelete.add(orderItemToDelete);
+            if (!orderItemsToDelete.contains(orderItemToDelete)) {
+                orderItemsToDelete.add(orderItemToDelete);
+            }
+        }
+        for (OrderItem orderItemToDelete:orderItemsToDelete) {
             model.deleteOrderItem(orderItemToDelete);
         }
-
         return new CommandResult(getResultString(orderItemsToDelete));
     }
 


### PR DESCRIPTION
* Fixed error in delete command where if an index is repeated two orders get deleted when only one should be deleted
* Fixed error in deleteItem command where if an index is repeated two order items get deleted
* Tests to be added soon!